### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Tests (Python 3.12 in Linux-64)
+          - name: Tests (Python 3.12 in Linux-x86_64)
             os: "ubuntu-latest"
             python-version: "3.12"
             extra-deps: "test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install Xspec
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,25 +86,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Tests (Python 3.9, Linux-x86_64)
-            os: "ubuntu-latest"
-            python-version: "3.9"
-
-          - name: Tests (Python 3.10, Linux-x86_64)
-            os: "ubuntu-latest"
-            python-version: "3.10"
-
-          - name: Tests (Python 3.11, Linux-x86_64)
-            os: "ubuntu-latest"
-            python-version: "3.11"
-
-          - name: Tests (Python 3.12, Linux-x86_64)
+          - name: Tests (Python 3.12 in Linux-64)
             os: "ubuntu-latest"
             python-version: "3.12"
+            extra-deps: "test"
 
-          - name: Tests (Python 3.12, macOS-arm64)
+          - name: Tests (Python 3.12 in macOS-arm64)
             os: "macos-latest"
             python-version: "3.12"
+            extra-deps: "test"
+
+          - name: Tests (Minimum Version Deps)
+            os: "ubuntu-latest"
+            python-version: "3.9"
+            extra-deps: "test,mindep"
     defaults:
       run:
         shell: bash -el {0}
@@ -130,7 +125,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install ".[test]" --verbose
+          pip install ".[${{ matrix.extra-deps }}]" --verbose
 
       - name: Run Tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,13 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "jax>=0.4.16,<0.6.0",
+    "jax>=0.4.16",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["coverage[toml]", "pytest", "pytest-cov"]
+mindep = ["jax==0.4.16"]
 
 [project.urls]
 Documentation = "https://github.com/wcxve/xspex#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["coverage[toml]", "pytest", "pytest-cov"]
-mindep = ["jax==0.4.16", "jaxlib==0.4.16"]
+mindep = ["jax==0.4.16", "jaxlib==0.4.16", "numpy<2"]
 
 [project.urls]
 Documentation = "https://github.com/wcxve/xspex#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["coverage[toml]", "pytest", "pytest-cov"]
+test = ["coverage[toml]", "pytest", "pytest-cov", "pytest-xdist"]
 mindep = ["jax==0.4.16", "jaxlib==0.4.16", "numpy<2"]
 
 [project.urls]
@@ -65,7 +65,7 @@ lint.select = [
 ]
 
 [tool.pytest]
-ini_options.addopts = "--cov=xspex --cov-report xml"
+ini_options.addopts = "-n auto --cov=xspex --cov-report xml"
 
 [tool.coverage]
 run.branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ classifiers = [
 dependencies = [
     "numpy",
     "jax>=0.4.16",
+    "jaxlib>=0.4.16",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["coverage[toml]", "pytest", "pytest-cov"]
-mindep = ["jax==0.4.16"]
+mindep = ["jax==0.4.16", "jaxlib==0.4.16"]
 
 [project.urls]
 Documentation = "https://github.com/wcxve/xspex#readme"

--- a/src/xspex/primitive.py
+++ b/src/xspex/primitive.py
@@ -20,6 +20,8 @@ except ImportError:
 # register_custom_call_target is replaced by register_ffi_target in jax>=0.6.0
 try:
     from jax.ffi import register_ffi_target
+
+    register_ffi_target = partial(register_ffi_target, api_version=0)
 except ImportError:
     from jax.lib import xla_client
 
@@ -285,7 +287,7 @@ def get_primitive(
 
 
 for k, v in xspex.xla_registrations().items():
-    register_ffi_target(k, v, platform='cpu', api_version=0)
+    register_ffi_target(k, v, platform='cpu')
 
 add = xspex.list_models(xspex.ModelType.Add)
 mul = xspex.list_models(xspex.ModelType.Mul)

--- a/src/xspex/primitive.py
+++ b/src/xspex/primitive.py
@@ -9,10 +9,21 @@ from math import prod
 import jax
 import jax.numpy as jnp
 from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from jax.interpreters import ad, batching, mlir, xla
-from jax.lib import xla_client
-from jaxlib.hlo_helpers import custom_call
+
+# Primitive is moved from jax.core to jax.extend.core in jax>=0.6.0
+try:
+    from jax.extend.core import Primitive
+except ImportError:
+    from jax.core import Primitive
+
+# register_custom_call_target is replaced by register_ffi_target in jax>=0.6.0
+try:
+    from jax.ffi import register_ffi_target
+except ImportError:
+    from jax.lib import xla_client
+
+    register_ffi_target = xla_client.register_custom_call_target
 
 import xspex
 
@@ -100,7 +111,7 @@ class XspecPrimitive(XspecPrimitiveBase):
         out_type = mlir.ir.RankedTensorType.get(out_shape, etype)
         out_n = mlir.ir_constant(out_shape[-1])
         out_batch = mlir.ir_constant(prod(out_shape[:-1]))
-        return custom_call(
+        return mlir.custom_call(
             call_target_name,
             result_types=[out_type],
             operands=[params, egrid, spec_num, out_n, out_batch],
@@ -206,7 +217,7 @@ class XspecConvPrimitive(XspecPrimitiveBase):
         out_type = mlir.ir.RankedTensorType.get(out_shape, etype)
         out_n = mlir.ir_constant(out_shape[-1])
 
-        return custom_call(
+        return mlir.custom_call(
             call_target_name,
             result_types=[out_type],
             operands=[
@@ -274,7 +285,7 @@ def get_primitive(
 
 
 for k, v in xspex.xla_registrations().items():
-    xla_client.register_custom_call_target(k, v, platform='cpu')
+    register_ffi_target(k, v, platform='cpu', api_version=0)
 
 add = xspex.list_models(xspex.ModelType.Add)
 mul = xspex.list_models(xspex.ModelType.Mul)


### PR DESCRIPTION
## Summary by Sourcery

Update the CI workflow to test fewer Python versions but add a specific job for minimum dependencies. Adjust the `jax` dependency constraint and update MLIR custom call usage.

Build:
- Remove the upper version constraint for the `jax` dependency.
- Define a 'mindep' optional dependency group for minimum version testing.

CI:
- Streamline the CI matrix to test Python 3.12 on Linux/macOS and Python 3.9 with minimum dependencies.
- Parameterize the installation of optional dependencies based on the CI job.