### PR TITLE
ci: cache `Xspec` conda package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
         id: cache-xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.PKG_DIR }}/${{ env.XSPEC_FN }}"
           key: "${{ env.PKG_DIR }}/${{ env.XSPEC_FN }}"
+          path: "${{ env.PKG_DIR }}/${{ env.XSPEC_FN }}"
           lookup-only: true
 
       - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
@@ -98,8 +98,9 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/cache@v4
         with:
-          path: "${{ env.PKG_DIR }}/${{ env.DATA_FN }}"
           key: "${{ env.PKG_DIR }}/${{ env.DATA_FN }}"
+          path: "${{ env.PKG_DIR }}/${{ env.DATA_FN }}"
+          enableCrossOsArchive: true
           lookup-only: true
 
       - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
@@ -184,15 +185,16 @@ jobs:
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: ${{ env.XSPEC }}
           key: ${{ env.XSPEC }}
+          path: ${{ env.XSPEC }}
           fail-on-cache-miss: true
 
       - name: Cache Xspec Model Data
         uses: actions/cache@v4
         with:
-          path: ${{ env.DATA }}
           key: ${{ env.DATA }}
+          path: ${{ env.DATA }}
+          enableCrossOsArchive: true
           fail-on-cache-miss: true
 
       - name: Install Xspec
@@ -258,8 +260,8 @@ jobs:
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: ${{ env.XSPEC }}
           key: ${{ env.XSPEC }}
+          path: ${{ env.XSPEC }}
           fail-on-cache-miss: true
 
       - name: Install Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
             echo "Failed to download from $XSPEC_URL"
             exit 1  # Exit with a non-zero status to fail the job
           fi
+          mv "$XSPEC_FN" "$CONDA_PKG_DIR"
 
       - name: Download Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
         if: runner.os == 'Linux' && steps.cache-xspec-model-data.outputs.cache-hit != 'true'
@@ -123,6 +124,7 @@ jobs:
             echo "Failed to download from $DATA_URL"
             exit 1  # Exit with a non-zero status to fail the job
           fi
+          mv "$DATA_FN" "$CONDA_PKG_DIR"
 
   tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-xspec}"
+          key: "${{ runner.os }}-Xspec}"
           lookup-only: true
 
       - name: Cache Xspec Model Data
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
-          key: "${{ runner.os }}-xspec-data}"
+          key: "${{ runner.os }}-Xspec-Data}"
           lookup-only: true
 
       - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
@@ -186,14 +186,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-xspec}"
+          key: "${{ runner.os }}-Xspec}"
           fail-on-cache-miss: true
 
       - name: Cache Xspec Model Data
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
-          key: "${{ runner.os }}-xspec-data}"
+          key: "${{ runner.os }}-Xspec-Data}"
           fail-on-cache-miss: true
 
       - name: Install Xspec
@@ -255,7 +255,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-xspec}"
+          key: "${{ runner.os }}-Xspec}"
           fail-on-cache-miss: true
 
       - name: Install Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Get Conda Package Path
         run: |
-          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
       - name: Cache Xspec
@@ -232,7 +232,7 @@ jobs:
 
       - name: Get Conda Package Path
         run: |
-          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
       - name: Cache Xspec
@@ -241,10 +241,6 @@ jobs:
           path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.xspec-fn }}"
           key: "${{ runner.os }}-${{ needs.cache.outputs.xspec-fn }}"
           fail-on-cache-miss: true
-
-      - name: Install Xspec
-        run: |
-          mamba install xspec -c $HEASARC_CHANNEL -c conda-forge -y
 
       - name: Install Xspec
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
 
       - name: Parse Package Info
         run: |
+          ls
           xspec=$(cat pkg-info-${{ runner.os }} | jq -r '.xspec')
           data=$(cat pkg-info-${{ runner.os }} | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
-          path: "./"
 
       - name: Parse Package Info
         run: |
-          ls
-          xspec=$(cat pkg-info-${{ runner.os }} | jq -r '.xspec')
-          data=$(cat pkg-info-${{ runner.os }} | jq -r '.data')
+          xspec=$(cat pkg-info.json | jq -r '.xspec')
+          data=$(cat pkg-info.json | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
           echo "DATA=$data" >> "$GITHUB_ENV"
 
@@ -256,11 +254,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
-          path: "./"
 
       - name: Parse Package Info
         run: |
-          xspec=$(cat pkg-info-${{ runner.os }} | jq -r '.xspec')
+          xspec=$(cat pkg-info.json | jq -r '.xspec')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
 
       - name: Cache Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           echo "XSPEC_BUILD=$xspec_build" >> "$GITHUB_ENV"
           echo "XSPEC_URL=$xspec_url" >> "$GITHUB_ENV"
           echo "XSPEC_FN=$xspec_fn" >> "$GITHUB_ENV"
-          echo "xspec-fn=$xspec_fn" >> "$GITHUB_OUTPUT"
 
           data_pkg=$(mamba search xspec-data -c $HEASARC_CHANNEL --json | get_latest_pkg)
           data_version=$(echo $data_pkg | jq -r '.version')
@@ -85,14 +84,13 @@ jobs:
           echo "DATA_BUILD=$data_build" >> "$GITHUB_ENV"
           echo "DATA_URL=$data_url" >> "$GITHUB_ENV"
           echo "DATA_FN=$data_fn" >> "$GITHUB_ENV"
-          echo "data-fn=$data_fn" >> "$GITHUB_OUTPUT"
 
       - name: Cache Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
         id: cache-xspec
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
-          key: "${{ runner.os }}-${{ env.XSPEC_VERSION }}-${{ env.XSPEC_BUILD }}"
+          key: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
           lookup-only: true
 
       - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
@@ -101,23 +99,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
-          key: "${{ env.DATA_VERSION }}-${{ env.DATA_BUILD }}"
-          lookup-only: true
-
-      - name: Cache Xspec
-        if: steps.cache-xspec.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-Xspec}"
-          lookup-only: true
-
-      - name: Cache Xspec Model Data
-        if: steps.cache-xspec-model-data.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
-          key: "${{ runner.os }}-Xspec-Data}"
+          key: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
           lookup-only: true
 
       - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
@@ -139,6 +121,21 @@ jobs:
             exit 1  # Exit with a non-zero status to fail the job
           fi
           mv "$DATA_FN" "$CONDA_PKG_DIR"
+
+      - name: Save Package Info as Artifact
+        run: |
+          echo '
+            {
+              "xspec": "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}",
+              "data": "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}",
+            }
+          ' > pkg-info.json
+
+      - name: Upload Package Info
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-info-${{ runner.os }}
+          path: pkg-info.json
 
   tests:
     name: ${{ matrix.name }}
@@ -177,23 +174,31 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Get Conda Package Path
+      - name: Download Package Info
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-info-${{ runner.os }}
+          path: pkg-info.json
+
+      - name: Parse Package Info
         run: |
-          pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
-          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+          xspec=$(jq -r '.xspec' pkg-info.json)
+          data=$(jq -r '.data' pkg-info.json)
+          echo "XSPEC=$xspec" >> "$GITHUB_ENV"
+          echo "DATA=$data" >> "$GITHUB_ENV"
 
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-Xspec}"
+          path: ${{ env.XSPEC }}
+          key: ${{ env.XSPEC }}
           fail-on-cache-miss: true
 
       - name: Cache Xspec Model Data
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
-          key: "${{ runner.os }}-Xspec-Data}"
+          path: ${{ env.DATA }}
+          key: ${{ env.DATA }}
           fail-on-cache-miss: true
 
       - name: Install Xspec
@@ -246,16 +251,22 @@ jobs:
           miniforge-version: latest
           python-version: "3.13"
 
-      - name: Get Conda Package Path
+      - name: Download Package Info
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-info-${{ runner.os }}
+          path: pkg-info.json
+
+      - name: Parse Package Info
         run: |
-          pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
-          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+          xspec=$(jq -r '.xspec' pkg-info.json)
+          echo "XSPEC=$xspec" >> "$GITHUB_ENV"
 
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
-          key: "${{ runner.os }}-Xspec}"
+          path: ${{ env.XSPEC }}
+          key: ${{ env.XSPEC }}
           fail-on-cache-miss: true
 
       - name: Install Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,8 +254,8 @@ jobs:
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.xspec-fn }}"
-          key: "${{ runner.os }}-${{ needs.cache.outputs.xspec-fn }}"
+          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
+          key: "${{ runner.os }}-xspec}"
           fail-on-cache-miss: true
 
       - name: Install Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Save Package Info as Artifact
         run: |
-          echo "{'xspec':'$PKG_DIR/$XSPEC_FN','data':'$PKG_DIR/$DATA_FN'}" > pkg.json
+          echo "{\"xspec\":\"$PKG_DIR/$XSPEC_FN\",\"data\":\"$PKG_DIR/$DATA_FN\"}" > pkg.json
 
       - name: Upload Package Info
         uses: actions/upload-artifact@v4
@@ -176,7 +176,6 @@ jobs:
 
       - name: Parse Package Info
         run: |
-          cat pkg.json
           xspec=$(cat pkg.json | jq -r '.xspec')
           data=$(cat pkg.json | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,14 @@ env:
 
 jobs:
   download:
-    name: Cache Xspec Model Data
-    runs-on: ubuntu-latest
+    name: Cache Xspec Conda Package
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
     outputs:
-      data-fn: ${{ steps.get_info.outputs.fn }}
+      xspec-fn: ${{ steps.package-info.outputs.xspec-fn }}
+      data-fn: ${{ steps.package-info.outputs.data-fn }}
     defaults:
       run:
         shell: bash -el {0}
@@ -33,12 +37,8 @@ jobs:
         with:
           miniforge-version: latest
 
-      - name: Install Utils
-        run: |
-          sudo apt-get install -y aria2 jq
-
-      - name: Get Latest Version of Xspec Model Data
-        id: get_info
+      - name: Get Latest Version of Xspec Conda Package
+        id: package-info
         run: |
           get_latest_pkg() {
             jq '
@@ -60,31 +60,62 @@ jobs:
             '
           }
 
-          data_pkg=$(mamba search xspec-data -c $HEASARC_CHANNEL --json | get_latest_pkg)
-          version=$(echo $data_pkg | jq -r '.version')
-          build=$(echo $data_pkg | jq -r '.build_string')
-          url=$(echo $data_pkg | jq -r '.url')
-          fn=$(echo $data_pkg | jq -r '.fn')
-          echo "VERSION=$version" >> "$GITHUB_ENV"
-          echo "BUILD=$build" >> "$GITHUB_ENV"
-          echo "URL=$url" >> "$GITHUB_ENV"
-          echo "FN=$fn" >> "$GITHUB_ENV"
-          echo "fn=$fn" >> "$GITHUB_OUTPUT"
+          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
-      - name: Cache Xspec Model Data ${{ env.VERSION }} (Build ${{ env.BUILD }})
+          xspec_pkg=$(mamba search xspec -c $HEASARC_CHANNEL --json | get_latest_pkg)
+          xspec_version=$(echo xspec_pkg | jq -r '.version')
+          xspec_build=$(echo xspec_pkg | jq -r '.build_string')
+          xspec_url=$(echo xspec_pkg | jq -r '.url')
+          xspec_fn=$(echo xspec_pkg | jq -r '.fn')
+          echo "XSPEC_VERSION=xspec_version" >> "$GITHUB_ENV"
+          echo "XSPEC_BUILD=xspec_build" >> "$GITHUB_ENV"
+          echo "XSPEC_URL=$xspec_url" >> "$GITHUB_ENV"
+          echo "XSPEC_FN=$xspec_fn" >> "$GITHUB_ENV"
+          echo "xspec-fn=$xspec_fn" >> "$GITHUB_OUTPUT"
+
+          data_pkg=$(mamba search xspec-data -c $HEASARC_CHANNEL --json | get_latest_pkg)
+          data_version=$(echo data_pkg | jq -r '.version')
+          data_build=$(echo data_pkg | jq -r '.build_string')
+          data_url=$(echo data_pkg | jq -r '.url')
+          data_fn=$(echo data_pkg | jq -r '.fn')
+          echo "DATA_VERSION=data_version" >> "$GITHUB_ENV"
+          echo "DATA_BUILD=data_build" >> "$GITHUB_ENV"
+          echo "DATA_URL=data_url" >> "$GITHUB_ENV"
+          echo "DATA_FN=data_fn" >> "$GITHUB_ENV"
+          echo "data-fn=data_fn" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
+        id: cache-xspec
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
+          key: "${{ runner.os }}-${{ env.XSPEC_FN }}"
+          lookup-only: true
+
+      - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
         id: cache-xspec-model-data
         uses: actions/cache@v4
         with:
-          path: ${{ env.FN }}
-          key: ${{ env.FN }}
+          path: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
+          key: "${{ env.DATA_FN }}"
           lookup-only: true
 
-      - name: Download Xspec Model Data ${{ env.VERSION }} (Build ${{ env.BUILD }})
-        if: steps.cache-xspec-model-data.outputs.cache-hit != 'true'
+      - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
+        if: steps.cache-xspec.outputs.cache-hit != 'true'
         run: |
-          aria2c -x 16 -s 16 --show-console-readout=true "$URL"
-          if [ ! -f "$FN" ]; then
-            echo "Failed to download from $URL"
+          aria2c -x 16 -s 16 --show-console-readout=true "$XSPEC_URL"
+          if [ ! -f "$XSPEC_FN" ]; then
+            echo "Failed to download from $XSPEC_URL"
+            exit 1  # Exit with a non-zero status to fail the job
+          fi
+
+      - name: Download Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
+        if: runner.os == 'Linux' && steps.cache-xspec-model-data.outputs.cache-hit != 'true'
+        run: |
+          aria2c -x 16 -s 16 --show-console-readout=true "$DATA_URL"
+          if [ ! -f "$DATA_FN" ]; then
+            echo "Failed to download from $DATA_URL"
             exit 1  # Exit with a non-zero status to fail the job
           fi
 
@@ -116,13 +147,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Cache Xspec Model Data
-        uses: actions/cache@v4
-        with:
-          path: ${{ needs.download.outputs.data-fn }}
-          key: ${{ needs.download.outputs.data-fn }}
-          fail-on-cache-miss: true
-
       - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -132,10 +156,28 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
 
+      - name: Get Conda Package Path
+        run: |
+          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+
+      - name: Cache Xspec
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.download.outputs.xspec-fn }}"
+          key: "${{ runner.os}}-${{ needs.download.outputs.xspec-fn }}"
+          fail-on-cache-miss: true
+
+      - name: Cache Xspec Model Data
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.download.outputs.data-fn }}"
+          key: "${{ runner.os}}-${{ needs.download.outputs.data-fn }}"
+          fail-on-cache-miss: true
+
       - name: Install Xspec
         run: |
-          mamba install xspec -c $HEASARC_CHANNEL -c conda-forge -y
-          conda install --use-local ${{ needs.download.outputs.data-fn }} -y
+          mamba install xspec xspec-data -c $HEASARC_CHANNEL -c conda-forge -y
 
       - name: Install Python Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   HEASARC_CHANNEL: "https://heasarc.gsfc.nasa.gov/FTP/software/conda"
 
 jobs:
-  download:
+  cache:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,31 +65,30 @@ jobs:
             '
           }
 
-          pkg_dir=$(mamba info --json | jq '.["package cache"][0]')
+          pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
-          echo $pkg_dir
 
           xspec_pkg=$(mamba search xspec -c $HEASARC_CHANNEL --json | get_latest_pkg)
-          xspec_version=$(echo xspec_pkg | jq -r '.version')
-          xspec_build=$(echo xspec_pkg | jq -r '.build_string')
-          xspec_url=$(echo xspec_pkg | jq -r '.url')
-          xspec_fn=$(echo xspec_pkg | jq -r '.fn')
-          echo "XSPEC_VERSION=xspec_version" >> "$GITHUB_ENV"
-          echo "XSPEC_BUILD=xspec_build" >> "$GITHUB_ENV"
+          xspec_version=$(echo $xspec_pkg | jq -r '.version')
+          xspec_build=$(echo $xspec_pkg | jq -r '.build_string')
+          xspec_url=$(echo $xspec_pkg | jq -r '.url')
+          xspec_fn=$(echo $xspec_pkg | jq -r '.fn')
+          echo "XSPEC_VERSION=$xspec_version" >> "$GITHUB_ENV"
+          echo "XSPEC_BUILD=$xspec_build" >> "$GITHUB_ENV"
           echo "XSPEC_URL=$xspec_url" >> "$GITHUB_ENV"
           echo "XSPEC_FN=$xspec_fn" >> "$GITHUB_ENV"
           echo "xspec-fn=$xspec_fn" >> "$GITHUB_OUTPUT"
 
           data_pkg=$(mamba search xspec-data -c $HEASARC_CHANNEL --json | get_latest_pkg)
-          data_version=$(echo data_pkg | jq -r '.version')
-          data_build=$(echo data_pkg | jq -r '.build_string')
-          data_url=$(echo data_pkg | jq -r '.url')
-          data_fn=$(echo data_pkg | jq -r '.fn')
-          echo "DATA_VERSION=data_version" >> "$GITHUB_ENV"
-          echo "DATA_BUILD=data_build" >> "$GITHUB_ENV"
-          echo "DATA_URL=data_url" >> "$GITHUB_ENV"
-          echo "DATA_FN=data_fn" >> "$GITHUB_ENV"
-          echo "data-fn=data_fn" >> "$GITHUB_OUTPUT"
+          data_version=$(echo $data_pkg | jq -r '.version')
+          data_build=$(echo $data_pkg | jq -r '.build_string')
+          data_url=$(echo $data_pkg | jq -r '.url')
+          data_fn=$(echo $data_pkg | jq -r '.fn')
+          echo "DATA_VERSION=$data_version" >> "$GITHUB_ENV"
+          echo "DATA_BUILD=$data_build" >> "$GITHUB_ENV"
+          echo "DATA_URL=$data_url" >> "$GITHUB_ENV"
+          echo "DATA_FN=$data_fn" >> "$GITHUB_ENV"
+          echo "data-fn=$data_fn" >> "$GITHUB_OUTPUT"
 
       - name: Cache Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
         id: cache-xspec
@@ -128,7 +127,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    needs: download
+    needs: cache
     strategy:
       matrix:
         include:
@@ -170,15 +169,15 @@ jobs:
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.download.outputs.xspec-fn }}"
-          key: "${{ runner.os}}-${{ needs.download.outputs.xspec-fn }}"
+          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.xspec-fn }}"
+          key: "${{ runner.os }}-${{ needs.cache.outputs.xspec-fn }}"
           fail-on-cache-miss: true
 
       - name: Cache Xspec Model Data
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.download.outputs.data-fn }}"
-          key: "${{ runner.os}}-${{ needs.download.outputs.data-fn }}"
+          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.data-fn }}"
+          key: "${{ runner.os }}-${{ needs.cache.outputs.data-fn }}"
           fail-on-cache-miss: true
 
       - name: Install Xspec
@@ -217,6 +216,7 @@ jobs:
   build:
     name: Build Source Distribution
     runs-on: ubuntu-latest
+    needs: cache
     defaults:
       run:
         shell: bash -el {0}
@@ -229,6 +229,22 @@ jobs:
         with:
           miniforge-version: latest
           python-version: "3.13"
+
+      - name: Get Conda Package Path
+        run: |
+          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+
+      - name: Cache Xspec
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.xspec-fn }}"
+          key: "${{ runner.os }}-${{ needs.cache.outputs.xspec-fn }}"
+          fail-on-cache-miss: true
+
+      - name: Install Xspec
+        run: |
+          mamba install xspec -c $HEASARC_CHANNEL -c conda-forge -y
 
       - name: Install Xspec
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
               "data": "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}",
             }
           ' > pkg-info.json
+          cat pkg-info.json
 
       - name: Upload Package Info
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,8 @@ jobs:
 
       - name: Parse Package Info
         run: |
-          xspec=$(jq -r '.xspec' pkg-info.json)
-          data=$(jq -r '.data' pkg-info.json)
+          xspec=$(cat pkg-info.json | jq -r '.xspec')
+          data=$(cat pkg-info.json | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
           echo "DATA=$data" >> "$GITHUB_ENV"
 
@@ -259,7 +259,7 @@ jobs:
 
       - name: Parse Package Info
         run: |
-          xspec=$(jq -r '.xspec' pkg-info.json)
+          xspec=$(cat pkg-info.json | jq -r '.xspec')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
 
       - name: Cache Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
-          key: "${{ runner.os }}-${{ env.XSPEC_FN }}"
+          key: "${{ runner.os }}-${{ env.XSPEC_VERSION }}-${{ env.XSPEC_BUILD }}"
           lookup-only: true
 
       - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
-          key: "${{ env.DATA_FN }}"
+          key: "${{ env.DATA_VERSION }}-${{ env.DATA_BUILD }}"
           lookup-only: true
 
       - name: Cache Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Save Package Info as Artifact
         run: |
           echo "{'xspec':'$PKG_DIR/$XSPEC_FN','data':'$PKG_DIR/$DATA_FN'}" > pkg.json
+          cat pkg.json
 
       - name: Upload Package Info
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
+          path: "./"
 
       - name: Parse Package Info
         run: |
@@ -254,6 +255,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
+          path: "./"
 
       - name: Parse Package Info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
-          path: pkg-info.json
 
       - name: Parse Package Info
         run: |
-          xspec=$(cat pkg-info.json | jq -r '.xspec')
-          data=$(cat pkg-info.json | jq -r '.data')
+          xspec=$(cat pkg-info-${{ runner.os }} | jq -r '.xspec')
+          data=$(cat pkg-info-${{ runner.os }} | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
           echo "DATA=$data" >> "$GITHUB_ENV"
 
@@ -255,11 +254,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-info-${{ runner.os }}
-          path: pkg-info.json
 
       - name: Parse Package Info
         run: |
-          xspec=$(cat pkg-info.json | jq -r '.xspec')
+          xspec=$(cat pkg-info-${{ runner.os }} | jq -r '.xspec')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
 
       - name: Cache Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
       - name: Save Package Info as Artifact
         run: |
           echo "{'xspec':'$PKG_DIR/$XSPEC_FN','data':'$PKG_DIR/$DATA_FN'}" > pkg.json
-          cat pkg.json
 
       - name: Upload Package Info
         uses: actions/upload-artifact@v4
@@ -177,6 +176,7 @@ jobs:
 
       - name: Parse Package Info
         run: |
+          cat pkg.json
           xspec=$(cat pkg.json | jq -r '.xspec')
           data=$(cat pkg.json | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Cache Xspec Conda Package (Linux-x64)
+          - name: Cache Xspec (Linux-x64)
             os: "ubuntu-latest"
 
-          - name: Cache Xspec Conda Package (macOS-arm64)
+          - name: Cache Xspec (macOS-arm64)
             os: "macos-latest"
-    outputs:
-      xspec-fn: ${{ steps.package-info.outputs.xspec-fn }}
-      data-fn: ${{ steps.package-info.outputs.data-fn }}
     defaults:
       run:
         shell: bash -el {0}
@@ -100,10 +97,27 @@ jobs:
 
       - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
         id: cache-xspec-model-data
+        if: runner.os == 'Linux'
         uses: actions/cache@v4
         with:
           path: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
           key: "${{ env.DATA_FN }}"
+          lookup-only: true
+
+      - name: Cache Xspec
+        if: steps.cache-xspec.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
+          key: "${{ runner.os }}-xspec}"
+          lookup-only: true
+
+      - name: Cache Xspec Model Data
+        if: steps.cache-xspec-model-data.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
+          key: "${{ runner.os }}-xspec-data}"
           lookup-only: true
 
       - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
@@ -171,15 +185,15 @@ jobs:
       - name: Cache Xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.xspec-fn }}"
-          key: "${{ runner.os }}-${{ needs.cache.outputs.xspec-fn }}"
+          path: "${{ env.CONDA_PKG_DIR }}/xspec-??.??*-.conda"
+          key: "${{ runner.os }}-xspec}"
           fail-on-cache-miss: true
 
       - name: Cache Xspec Model Data
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ needs.cache.outputs.data-fn }}"
-          key: "${{ runner.os }}-${{ needs.cache.outputs.data-fn }}"
+          path: "${{ env.CONDA_PKG_DIR }}/xspec-data-*.conda"
+          key: "${{ runner.os }}-xspec-data}"
           fail-on-cache-miss: true
 
       - name: Install Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
 
           pkg_dir=$(mamba info --json | jq '.["package cache"][0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+          echo $pkg_dir
 
           xspec_pkg=$(mamba search xspec -c $HEASARC_CHANNEL --json | get_latest_pkg)
           xspec_version=$(echo xspec_pkg | jq -r '.version')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           }
 
           pkg_dir=$(conda info --json | jq -r '.pkgs_dirs[0]')
-          echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
+          echo "PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
           xspec_pkg=$(mamba search xspec -c $HEASARC_CHANNEL --json | get_latest_pkg)
           xspec_version=$(echo $xspec_pkg | jq -r '.version')
@@ -89,8 +89,8 @@ jobs:
         id: cache-xspec
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
-          key: "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}"
+          path: "${{ env.PKG_DIR }}/${{ env.XSPEC_FN }}"
+          key: "${{ env.PKG_DIR }}/${{ env.XSPEC_FN }}"
           lookup-only: true
 
       - name: Cache Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
@@ -98,8 +98,8 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/cache@v4
         with:
-          path: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
-          key: "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}"
+          path: "${{ env.PKG_DIR }}/${{ env.DATA_FN }}"
+          key: "${{ env.PKG_DIR }}/${{ env.DATA_FN }}"
           lookup-only: true
 
       - name: Download Xspec ${{ env.XSPEC_VERSION }} (Build ${{ env.XSPEC_BUILD }})
@@ -110,7 +110,7 @@ jobs:
             echo "Failed to download from $XSPEC_URL"
             exit 1  # Exit with a non-zero status to fail the job
           fi
-          mv "$XSPEC_FN" "$CONDA_PKG_DIR"
+          mv "$XSPEC_FN" "$PKG_DIR"
 
       - name: Download Xspec Model Data ${{ env.DATA_VERSION }} (Build ${{ env.DATA_BUILD }})
         if: runner.os == 'Linux' && steps.cache-xspec-model-data.outputs.cache-hit != 'true'
@@ -120,23 +120,17 @@ jobs:
             echo "Failed to download from $DATA_URL"
             exit 1  # Exit with a non-zero status to fail the job
           fi
-          mv "$DATA_FN" "$CONDA_PKG_DIR"
+          mv "$DATA_FN" "$PKG_DIR"
 
       - name: Save Package Info as Artifact
         run: |
-          echo '
-            {
-              "xspec": "${{ env.CONDA_PKG_DIR }}/${{ env.XSPEC_FN }}",
-              "data": "${{ env.CONDA_PKG_DIR }}/${{ env.DATA_FN }}",
-            }
-          ' > pkg-info.json
-          cat pkg-info.json
+          echo "{'xspec':'$PKG_DIR/$XSPEC_FN','data':'$PKG_DIR/$DATA_FN'}" > pkg.json
 
       - name: Upload Package Info
         uses: actions/upload-artifact@v4
         with:
-          name: pkg-info-${{ runner.os }}
-          path: pkg-info.json
+          name: pkg-${{ runner.os }}
+          path: pkg.json
 
   tests:
     name: ${{ matrix.name }}
@@ -178,12 +172,12 @@ jobs:
       - name: Download Package Info
         uses: actions/download-artifact@v4
         with:
-          name: pkg-info-${{ runner.os }}
+          name: pkg-${{ runner.os }}
 
       - name: Parse Package Info
         run: |
-          xspec=$(cat pkg-info.json | jq -r '.xspec')
-          data=$(cat pkg-info.json | jq -r '.data')
+          xspec=$(cat pkg.json | jq -r '.xspec')
+          data=$(cat pkg.json | jq -r '.data')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
           echo "DATA=$data" >> "$GITHUB_ENV"
 
@@ -254,11 +248,11 @@ jobs:
       - name: Download Package Info
         uses: actions/download-artifact@v4
         with:
-          name: pkg-info-${{ runner.os }}
+          name: pkg-${{ runner.os }}
 
       - name: Parse Package Info
         run: |
-          xspec=$(cat pkg-info.json | jq -r '.xspec')
+          xspec=$(cat pkg.json | jq -r '.xspec')
           echo "XSPEC=$xspec" >> "$GITHUB_ENV"
 
       - name: Cache Xspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
             '
           }
 
-          mamba info --json
-          pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
+          pkg_dir=$(mamba info --json | jq '.["package cache"][0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
           xspec_pkg=$(mamba search xspec -c $HEASARC_CHANNEL --json | get_latest_pkg)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,16 @@ env:
 
 jobs:
   download:
-    name: Cache Xspec Conda Package
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        include:
+          - name: Cache Xspec Conda Package (Linux-x64)
+            os: "ubuntu-latest"
+
+          - name: Cache Xspec Conda Package (macOS-arm64)
+            os: "macos-latest"
     outputs:
       xspec-fn: ${{ steps.package-info.outputs.xspec-fn }}
       data-fn: ${{ steps.package-info.outputs.data-fn }}
@@ -60,6 +65,7 @@ jobs:
             '
           }
 
+          mamba info --json
           pkg_dir=$(conda info --json | jq '.pkgs_dirs[0]')
           echo "CONDA_PKG_DIR=$pkg_dir" >> "$GITHUB_ENV"
 
@@ -126,7 +132,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Tests (Python 3.13 in Linux-x86_64)
+          - name: Tests (Python 3.13 in Linux-x64)
             os: "ubuntu-latest"
             python-version: "3.13"
             uv-resolution: "highest"


### PR DESCRIPTION
## Summary by Sourcery

Cache the Xspec conda package and its model data in the CI workflow and update downstream jobs to restore from cache.

Enhancements:
- Dynamically retrieve and export the latest Xspec and Xspec-data package metadata (version, build, URL, filename) via mamba search and jq before caching.

CI:
- Add a dedicated "cache" job that runs on Linux-x64 and macOS-arm64 to fetch and cache both Xspec and Xspec-data conda packages.
- Refactor download steps to use actions/cache@v4 with lookup-only and only download packages on cache miss.
- Update tests and build jobs to depend on the cache job and restore Xspec packages from cache for installation.

Chores:
- Standardize matrix naming (e.g., Linux-x64) for consistency.